### PR TITLE
feat: add support for RESTful methods (GET, POST, PUT, DELETE)

### DIFF
--- a/example_plugins/restful_plugin.py
+++ b/example_plugins/restful_plugin.py
@@ -1,0 +1,77 @@
+"""Example RESTful plugin demonstrating support for different HTTP methods."""
+# Import local modules
+from webhook_bridge.plugin import BasePlugin
+
+
+class Plugin(BasePlugin):
+    """Example RESTful plugin demonstrating support for different HTTP methods.
+    
+    This plugin implements handlers for GET, POST, PUT, and DELETE methods.
+    """
+    
+    def handle(self) -> dict:
+        """Generic handler for the plugin.
+        
+        This method is called when no specific method handler is available
+        or as a fallback.
+        
+        Returns:
+            dict: Dictionary containing the plugin's results
+        """
+        return {
+            "status": "success",
+            "message": f"Generic handler called with method {self.http_method}",
+            "data": self.data
+        }
+    
+    def get(self) -> dict:
+        """Handle GET requests.
+        
+        Returns:
+            dict: Dictionary containing the plugin's results
+        """
+        return {
+            "status": "success",
+            "message": "GET request processed",
+            "data": self.data,
+            "resource_id": self.data.get("id", "all")
+        }
+    
+    def post(self) -> dict:
+        """Handle POST requests.
+        
+        Returns:
+            dict: Dictionary containing the plugin's results
+        """
+        return {
+            "status": "success",
+            "message": "Resource created",
+            "data": self.data,
+            "resource_id": "new_id_123"
+        }
+    
+    def put(self) -> dict:
+        """Handle PUT requests.
+        
+        Returns:
+            dict: Dictionary containing the plugin's results
+        """
+        return {
+            "status": "success",
+            "message": "Resource updated",
+            "data": self.data,
+            "resource_id": self.data.get("id", "unknown")
+        }
+    
+    def delete(self) -> dict:
+        """Handle DELETE requests.
+        
+        Returns:
+            dict: Dictionary containing the plugin's results
+        """
+        return {
+            "status": "success",
+            "message": "Resource deleted",
+            "data": self.data,
+            "resource_id": self.data.get("id", "unknown")
+        }

--- a/example_plugins/test_plugin.py
+++ b/example_plugins/test_plugin.py
@@ -1,8 +1,13 @@
-
+"""Test plugin for webhook bridge."""
 # Import local modules
 from webhook_bridge.plugin import BasePlugin
 
 
 class Plugin(BasePlugin):
-    def run(self) -> dict:
-        return {"status": "success", "message": "Test plugin executed"}
+    def handle(self) -> dict:
+        """Generic handler for the plugin.
+
+        Returns:
+            dict: Dictionary containing the plugin's results
+        """
+        return {"status": "success", "message": f"Test plugin executed with {self.http_method} method"}

--- a/webhook_bridge/api/call_plugin.py
+++ b/webhook_bridge/api/call_plugin.py
@@ -30,23 +30,21 @@ def api(app: FastAPI) -> None:
     """
     router = APIRouter()
 
-    @router.post(
-        "/plugin/{plugin_name}",
-        response_model=WebhookResponseData,
-        summary="Execute a plugin",
-        description="Execute a specific webhook plugin with the provided data",
-        status_code=status.HTTP_200_OK,
-        responses={
-            200: {
-                "description": "Plugin executed successfully",
-                "content": {
-                    "application/json": {
-                        "example": {
-                            "status_code": 200,
-                            "message": "success",
-                            "data": {
-                                "plugin": "example",
-                                "src_data": {"key": "value"},
+    # Common response definitions for all HTTP methods
+    plugin_responses = {
+        200: {
+            "description": "Plugin executed successfully",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "status_code": 200,
+                        "message": "success",
+                        "data": {
+                            "plugin": "example",
+                            "plugin_data": {
+                                "input_data": {"key": "value"},
+                                "additional_info": "This is some additional information.",
+                                "http_method": "POST",
                                 "result": {
                                     "status": "success",
                                     "data": {"key": "value"},
@@ -56,41 +54,43 @@ def api(app: FastAPI) -> None:
                     },
                 },
             },
-            404: {
-                "description": "Plugin not found",
-                "content": {
-                    "application/json": {
-                        "example": {
-                            "status_code": 404,
-                            "message": "Plugin not found",
-                            "data": {
-                                "error": "Plugin not found",
-                            },
-                        },
-                    },
-                },
-            },
-            500: {
-                "description": "Plugin execution failed",
-                "content": {
-                    "application/json": {
-                        "example": {
-                            "status_code": 500,
-                            "message": "Plugin execution failed",
-                            "data": {
-                                "details": "Error message",
-                            },
+        },
+        404: {
+            "description": "Plugin not found",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "status_code": 404,
+                        "message": "Plugin not found",
+                        "data": {
+                            "error": "Plugin not found",
                         },
                     },
                 },
             },
         },
-    )
-    @version(1)
-    async def execute_plugin(
+        500: {
+            "description": "Plugin execution failed",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "status_code": 500,
+                        "message": "Plugin execution failed",
+                        "data": {
+                            "details": "Error message",
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    # Helper function to execute a plugin
+    async def _execute_plugin(
         request: Request,
         plugin_name: str,
         data: dict[str, Any],
+        http_method: str,
     ) -> WebhookResponse:
         """Execute a specific webhook plugin.
 
@@ -98,12 +98,13 @@ def api(app: FastAPI) -> None:
             request: FastAPI request object
             plugin_name: Name of the plugin to execute
             data: Data to pass to the plugin
+            http_method: HTTP method used to call the plugin
 
         Returns:
             WebhookResponse: Response containing the plugin execution results
         """
         logger = logging.getLogger(__name__)
-        logger.info("Executing plugin %r with data: %s", plugin_name, data)
+        logger.info("Executing plugin %r with method %r and data: %s", plugin_name, http_method, data)
 
         # Get plugin directory from app state
         plugin_dir = app.state.plugin_dir
@@ -134,10 +135,10 @@ def api(app: FastAPI) -> None:
         try:
             # Load and execute plugin
             plugin_class: type[BasePlugin] = load_plugin(plugin_src_file)
-            plugin_instance = plugin_class(data)
+            plugin_instance = plugin_class(data, http_method=http_method)
             result = plugin_instance.execute()
 
-            logger.info("Successfully executed plugin %r", plugin_name)
+            logger.info("Successfully executed plugin %r with method %r", plugin_name, http_method)
             return WebhookResponse(
                 status_code=status.HTTP_200_OK,
                 message="success",
@@ -151,8 +152,9 @@ def api(app: FastAPI) -> None:
             logger.debug(traceback.format_exc())
             error_msg = str(e)
             logger.error(
-                "Failed to execute plugin %r: %s\n%s",
+                "Failed to execute plugin %r with method %r: %s\n%s",
                 plugin_name,
+                http_method,
                 error_msg,
                 traceback.format_exc(),
             )
@@ -163,5 +165,116 @@ def api(app: FastAPI) -> None:
                     "details": error_msg,
                 },
             )
+
+    # POST endpoint
+    @router.post(
+        "/plugin/{plugin_name}",
+        response_model=WebhookResponseData,
+        summary="Execute a plugin with POST",
+        description="Execute a specific webhook plugin with the provided data using POST method",
+        status_code=status.HTTP_200_OK,
+        responses=plugin_responses,
+    )
+    @version(1)
+    async def execute_plugin_post(
+        request: Request,
+        plugin_name: str,
+        data: dict[str, Any],
+    ) -> WebhookResponse:
+        """Execute a specific webhook plugin using POST method.
+
+        Args:
+            request: FastAPI request object
+            plugin_name: Name of the plugin to execute
+            data: Data to pass to the plugin
+
+        Returns:
+            WebhookResponse: Response containing the plugin execution results
+        """
+        # For backward compatibility, log a message if the plugin uses the run method
+        logger = logging.getLogger(__name__)
+        logger.info(f"Executing plugin {plugin_name} with POST method")
+        return await _execute_plugin(request, plugin_name, data, "POST")
+
+    # GET endpoint
+    @router.get(
+        "/plugin/{plugin_name}",
+        response_model=WebhookResponseData,
+        summary="Execute a plugin with GET",
+        description="Execute a specific webhook plugin using GET method",
+        status_code=status.HTTP_200_OK,
+        responses=plugin_responses,
+    )
+    @version(1)
+    async def execute_plugin_get(
+        request: Request,
+        plugin_name: str,
+    ) -> WebhookResponse:
+        """Execute a specific webhook plugin using GET method.
+
+        Args:
+            request: FastAPI request object
+            plugin_name: Name of the plugin to execute
+
+        Returns:
+            WebhookResponse: Response containing the plugin execution results
+        """
+        # For GET requests, we extract query parameters as data
+        data = dict(request.query_params)
+        return await _execute_plugin(request, plugin_name, data, "GET")
+
+    # PUT endpoint
+    @router.put(
+        "/plugin/{plugin_name}",
+        response_model=WebhookResponseData,
+        summary="Execute a plugin with PUT",
+        description="Execute a specific webhook plugin with the provided data using PUT method",
+        status_code=status.HTTP_200_OK,
+        responses=plugin_responses,
+    )
+    @version(1)
+    async def execute_plugin_put(
+        request: Request,
+        plugin_name: str,
+        data: dict[str, Any],
+    ) -> WebhookResponse:
+        """Execute a specific webhook plugin using PUT method.
+
+        Args:
+            request: FastAPI request object
+            plugin_name: Name of the plugin to execute
+            data: Data to pass to the plugin
+
+        Returns:
+            WebhookResponse: Response containing the plugin execution results
+        """
+        return await _execute_plugin(request, plugin_name, data, "PUT")
+
+    # DELETE endpoint
+    @router.delete(
+        "/plugin/{plugin_name}",
+        response_model=WebhookResponseData,
+        summary="Execute a plugin with DELETE",
+        description="Execute a specific webhook plugin using DELETE method",
+        status_code=status.HTTP_200_OK,
+        responses=plugin_responses,
+    )
+    @version(1)
+    async def execute_plugin_delete(
+        request: Request,
+        plugin_name: str,
+    ) -> WebhookResponse:
+        """Execute a specific webhook plugin using DELETE method.
+
+        Args:
+            request: FastAPI request object
+            plugin_name: Name of the plugin to execute
+
+        Returns:
+            WebhookResponse: Response containing the plugin execution results
+        """
+        # For DELETE requests, we extract query parameters as data
+        data = dict(request.query_params)
+        return await _execute_plugin(request, plugin_name, data, "DELETE")
 
     app.include_router(router)


### PR DESCRIPTION
## Description

This PR adds support for different HTTP methods (GET, POST, PUT, DELETE) to the webhook_bridge plugin system, enabling plugins to handle various RESTful requests.

## Key Changes

1. Modified the `BasePlugin` class to support different HTTP methods:
   - Added an `http_method` parameter to specify the current HTTP method
   - Added a `handle` method as a generic handler
   - Added `get`, `post`, `put`, and `delete` methods as specific HTTP method handlers
   - Preserved the `run` method for backward compatibility, but added deprecation warnings

2. Modified the route definitions in `call_plugin.py`:
   - Added support for GET, POST, PUT, and DELETE methods to the same path `/plugin/{plugin_name}`
   - Each HTTP method has its own handler function but shares the same path

3. Created a new example plugin `restful_plugin.py` demonstrating how to use the new HTTP method support

4. Updated test files to ensure all HTTP methods work correctly

## Usage

Plugins can now implement specific HTTP method handlers:

```python
class MyPlugin(BasePlugin):
    def handle(self) -> dict:
        # Generic handler
        return {"status": "success"}
        
    def get(self) -> dict:
        # Handle GET requests
        return {"status": "success", "method": "GET"}
        
    def post(self) -> dict:
        # Handle POST requests
        return {"status": "success", "method": "POST"}
```

Clients can use different HTTP methods to call the same endpoint:

```bash
# GET request
curl -X GET "http://localhost:8000/v1/plugin/my_plugin?param=value"

# POST request
curl -X POST "http://localhost:8000/v1/plugin/my_plugin" \
     -H "Content-Type: application/json" \
     -d '{"param": "value"}'
```

Signed-off-by: longhao <hal.long@outlook.com>

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author